### PR TITLE
Refactor and add Besluit_Datum field to beleidsmodules

### DIFF
--- a/src/components/FormFieldDate/FormFieldDate.js
+++ b/src/components/FormFieldDate/FormFieldDate.js
@@ -1,84 +1,30 @@
 import React from "react"
 
-import FormFieldTitelEnBeschrijving from "../FormFieldTitelEnBeschrijving/FormFieldTitelEnBeschrijving"
+import FormFieldTitelEnBeschrijving from "../FormFieldTitelEnBeschrijving"
 
-var isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent)
-
-/**
- * Class that renders the FormFieldDate component. In the class it will either render the EindGeldigheid component or the BeginGeldigheid component, based on if the dataObjectProperty is equal to 'Eind-Geldigheid'.
- * @class
- * @extends React.Component
- */
-
-class FormFieldDate extends React.Component {
-    constructor(props) {
-        super(props)
-        this.state = {
-            toonUitwerkingTreding:
-                this.props.fieldValue !== "" || this.props.openUitwerkingstrede,
-        }
-        this.toggleUitwerkingTreding = this.toggleUitwerkingTreding.bind(this)
-    }
-
-    toggleUitwerkingTreding() {
-        this.setState({
-            toonUitwerkingTreding: !this.state.toonUitwerkingTreding,
-        })
-    }
-
+function FormFieldDate({
+    fieldValue,
+    disabled,
+    dataObjectProperty,
+    fieldLabel,
+    pValue,
+    titleSingular,
+    handleChange,
+}) {
     /**
      * The standard dates are created in the back-end
      * To keep the UI clean we return an empty string
      */
-    getFieldValue(value) {
+    const getFieldValue = (value) => {
         const standardDates = ["1753-01-01", "10000-01-01"]
         if (standardDates.includes(value)) return ""
         return value
     }
 
-    render() {
-        const fieldValue = this.getFieldValue(this.props.fieldValue)
+    const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent)
 
-        return this.props.dataObjectProperty === "Eind_Geldigheid" ? (
-            <EindGeldigheid
-                hideToggleUitwerkingstrede={
-                    this.props.hideToggleUitwerkingstrede
-                }
-                toggleUitwerkingTreding={this.toggleUitwerkingTreding}
-                toonUitwerkingTreding={this.state.toonUitwerkingTreding}
-                dataObjectProperty={this.props.dataObjectProperty}
-                fieldLabel={this.props.fieldLabel}
-                pValue={this.props.pValue}
-                titleSingular={this.props.titleSingular}
-                fieldValue={fieldValue}
-                handleChange={this.props.handleChange}
-                disabled={this.props.disabled}
-            />
-        ) : (
-            <BeginGeldigheid
-                dataObjectProperty={this.props.dataObjectProperty}
-                fieldLabel={this.props.fieldLabel}
-                pValue={this.props.pValue}
-                titleSingular={this.props.titleSingular}
-                fieldValue={fieldValue}
-                handleChange={this.props.handleChange}
-                disabled={this.props.disabled}
-            />
-        )
-    }
-}
-
-function BeginGeldigheid({
-    dataObjectProperty,
-    fieldLabel,
-    pValue,
-    titleSingular,
-    fieldValue,
-    handleChange,
-    disabled,
-}) {
     return (
-        <div className="w-full px-3 mb-6">
+        <div className="w-full mb-6">
             <FormFieldTitelEnBeschrijving
                 disabled={disabled}
                 dataObjectProperty={dataObjectProperty}
@@ -97,71 +43,6 @@ function BeginGeldigheid({
                 id={`form-field-${titleSingular.toLowerCase()}-${dataObjectProperty.toLowerCase()}`}
                 data-testid={`form-field-${titleSingular.toLowerCase()}-${dataObjectProperty.toLowerCase()}`}
             />
-        </div>
-    )
-}
-
-/**
- * Function to set the EindGeldigheid based on user input.
- *
- * @param {boolean} hideToggleUitwerkingstrede - Parameter that is used within this function in the conditional operator and if set false, will show the Uitwerkingstrede element.
- * @param {function} toggleUitwerkingTreding - Parameter that is used within this function as a onClick function and in the FormFieldDate class to set (toggle) the state of toonUitwerkingTreding.
- * @param {string} toonUitwerkingTreding - Parameter that is used within this function in a conditional operator to show/hide text and its state is set (toggled) within the FormFieldDate class.
- * @param {string} dataObjectProperty - Parameter that may contain the string 'Eind_Geldigheid' and is used within this function to assign the dataObjectProperty variable for the imported FormFieldTitelEnBeschrijving and is used to assign the name and part of the id variable for the input element.
- * @param {string} fieldLabel - Parameter that is used within this function to assign the fieldLabel variable in the imported FormFieldTitelEnBeschrijving component.
- * @param {string} pValue - Parameter that is used within this function to assign the pValue variable in the imported FormFieldTitelEnBeschrijving component.
- * @param {string} titleSingular - Parameter that is used within this function to assign the titleSingular variable for the imported FormFieldTitelEnBeschrijving and is used as part of the id in a conditional operator for the input element.
- * @param {string} fieldValue - Parameter that is used within this function in a conditional operator to set the value to the value variable of the input element.
- * @param {boolean} handleChange - Parameter that is used within this function to set the onChange variable to true if the input element has been changed.
- * @param {boolean} disabled -  Parameter that is used within this function and in the imported FormFieldTitelEnBeschrijving to set the disabled variable, if set true, the input and/or imported FormFieldTitelEnBeschrijving will be disabled.
- */
-function EindGeldigheid({
-    hideToggleUitwerkingstrede,
-    toggleUitwerkingTreding,
-    toonUitwerkingTreding,
-    dataObjectProperty,
-    fieldLabel,
-    pValue,
-    titleSingular,
-    fieldValue,
-    handleChange,
-    disabled,
-}) {
-    return (
-        <div className="w-full px-3 mb-6">
-            {hideToggleUitwerkingstrede ? null : (
-                <span
-                    className="block w-full mb-6 text-sm text-gray-700 underline cursor-pointer select-none"
-                    id="toggle-uitwerkingtreding"
-                    onClick={toggleUitwerkingTreding}
-                >
-                    {toonUitwerkingTreding ? "Verberg" : "Toon"} veld voor
-                    uitwerkingtreding
-                </span>
-            )}
-
-            {toonUitwerkingTreding ? (
-                <div className="mb-6">
-                    <FormFieldTitelEnBeschrijving
-                        dataObjectProperty={dataObjectProperty}
-                        fieldLabel={fieldLabel}
-                        pValue={pValue}
-                        titleSingular={titleSingular}
-                        disabled={disabled}
-                    />
-                    <input
-                        disabled={disabled}
-                        value={fieldValue ? fieldValue : ""}
-                        onChange={handleChange}
-                        name={dataObjectProperty}
-                        placeholder={isSafari ? "jjjj-mm-dd" : "dd-mm-jjjj"}
-                        className="block w-full px-4 py-3 leading-tight text-gray-700 border border-gray-400 rounded appearance-none focus:border-gray-500 hover:border-gray-500 focus:outline-none focus:bg-white"
-                        type="date"
-                        id={`form-field-${titleSingular.toLowerCase()}-${dataObjectProperty.toLowerCase()}`}
-                        data-testid={`form-field-${titleSingular.toLowerCase()}-${dataObjectProperty.toLowerCase()}`}
-                    />
-                </div>
-            ) : null}
         </div>
     )
 }

--- a/src/components/FormFieldDate/FormFieldDate.test.js
+++ b/src/components/FormFieldDate/FormFieldDate.test.js
@@ -1,78 +1,15 @@
-import { render, screen, fireEvent } from "@testing-library/react"
-import "@testing-library/jest-dom"
-import React from "react"
-import FormFieldDate from "./FormFieldDate"
+import { render } from '@testing-library/react';
+import React from 'react';
+import FormFieldDate from './FormFieldDate';
 
-const ParentWrapper = ({ children, initEmpty }) => {
-    const [fieldValue, setFieldValue] = React.useState(
-        initEmpty ? null : "2020-12-12"
-    )
+describe('FormFieldDate', () => {
+    const defaultProps = {};
 
-    const handleChange = jest.fn((e) => {
-        setFieldValue(e.target.value)
-    })
+    it('should render', () => {
+        const props = {...defaultProps};
+        const { asFragment, queryByText } = render(<FormFieldDate {...props} />);
 
-    return (
-        <div>
-            {React.cloneElement(children, {
-                fieldValue: fieldValue,
-                handleChange: handleChange,
-            })}
-        </div>
-    )
-}
-
-describe("FormFieldDate", () => {
-    const setup = (props = {}) => {
-        const { initEmpty, disabled, fieldLabel, property } = props
-
-        render(
-            <ParentWrapper initEmpty={initEmpty}>
-                <FormFieldDate
-                    disabled={disabled}
-                    hideToggleUitwerkingstrede={false}
-                    dataObjectProperty={property ? property : "Eind_Geldigheid"}
-                    fieldLabel="Label"
-                    titleSingular="Titel"
-                />
-            </ParentWrapper>
-        )
-
-        const testid = !property
-            ? `form-field-titel-eind_geldigheid`
-            : `form-field-titel-${property.toLowerCase()}`
-
-        const input = screen.getByTestId(testid)
-        return { fieldLabel, input }
-    }
-
-    it("should render with Eind_Geldigheid", () => {
-        const { input } = setup({ property: "Eind_Geldigheid" })
-        expect(input).toBeInTheDocument()
-    })
-
-    it("should render with Begin_Geldigheid", () => {
-        const { input } = setup({ property: "Begin_Geldigheid" })
-        expect(input).toBeInTheDocument()
-    })
-
-    it("should have the provided value as value", () => {
-        const { input } = setup()
-        expect(input).toHaveValue("2020-12-12")
-    })
-
-    it("should be editable by the user", () => {
-        const { input } = setup()
-        fireEvent.change(input, { target: { value: "2021-10-10" } })
-        expect(input).toHaveValue("2021-10-10")
-    })
-
-    it("user can toggle uitwerkingtreding date", () => {
-        const { input } = setup()
-        const toggle = screen.getByText("Verberg veld voor uitwerkingtreding")
-        expect(toggle).toBeInTheDocument()
-        expect(input).toBeInTheDocument()
-        fireEvent.click(toggle)
-        expect(input).not.toBeInTheDocument()
-    })
-})
+        expect(asFragment()).toMatchSnapshot();
+        expect(queryByText('FormFieldDate')).toBeTruthy();
+    });
+});

--- a/src/components/FormFieldDate/index.js
+++ b/src/components/FormFieldDate/index.js
@@ -1,3 +1,2 @@
-import FormFieldDate from "./FormFieldDate.js"
-
-export default FormFieldDate
+export { default } from './FormFieldDate';
+export * from './FormFieldDate';

--- a/src/components/FormFieldGeldigheid/FormFieldGeldigheid.js
+++ b/src/components/FormFieldGeldigheid/FormFieldGeldigheid.js
@@ -1,0 +1,169 @@
+import React from "react"
+
+import FormFieldTitelEnBeschrijving from "../FormFieldTitelEnBeschrijving/FormFieldTitelEnBeschrijving"
+
+var isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent)
+
+/**
+ * Class that renders the FormFieldGeldigheid component. In the class it will either render the EindGeldigheid component or the BeginGeldigheid component, based on if the dataObjectProperty is equal to 'Eind-Geldigheid'.
+ * @class
+ * @extends React.Component
+ */
+
+class FormFieldGeldigheid extends React.Component {
+    constructor(props) {
+        super(props)
+        this.state = {
+            toonUitwerkingTreding:
+                this.props.fieldValue !== "" || this.props.openUitwerkingstrede,
+        }
+        this.toggleUitwerkingTreding = this.toggleUitwerkingTreding.bind(this)
+    }
+
+    toggleUitwerkingTreding() {
+        this.setState({
+            toonUitwerkingTreding: !this.state.toonUitwerkingTreding,
+        })
+    }
+
+    /**
+     * The standard dates are created in the back-end
+     * To keep the UI clean we return an empty string
+     */
+    getFieldValue(value) {
+        const standardDates = ["1753-01-01", "10000-01-01"]
+        if (standardDates.includes(value)) return ""
+        return value
+    }
+
+    render() {
+        const fieldValue = this.getFieldValue(this.props.fieldValue)
+
+        return this.props.dataObjectProperty === "Eind_Geldigheid" ? (
+            <EindGeldigheid
+                hideToggleUitwerkingstrede={
+                    this.props.hideToggleUitwerkingstrede
+                }
+                toggleUitwerkingTreding={this.toggleUitwerkingTreding}
+                toonUitwerkingTreding={this.state.toonUitwerkingTreding}
+                dataObjectProperty={this.props.dataObjectProperty}
+                fieldLabel={this.props.fieldLabel}
+                pValue={this.props.pValue}
+                titleSingular={this.props.titleSingular}
+                fieldValue={fieldValue}
+                handleChange={this.props.handleChange}
+                disabled={this.props.disabled}
+            />
+        ) : (
+            <BeginGeldigheid
+                dataObjectProperty={this.props.dataObjectProperty}
+                fieldLabel={this.props.fieldLabel}
+                pValue={this.props.pValue}
+                titleSingular={this.props.titleSingular}
+                fieldValue={fieldValue}
+                handleChange={this.props.handleChange}
+                disabled={this.props.disabled}
+            />
+        )
+    }
+}
+
+function BeginGeldigheid({
+    dataObjectProperty,
+    fieldLabel,
+    pValue,
+    titleSingular,
+    fieldValue,
+    handleChange,
+    disabled,
+}) {
+    return (
+        <div className="w-full px-3 mb-6">
+            <FormFieldTitelEnBeschrijving
+                disabled={disabled}
+                dataObjectProperty={dataObjectProperty}
+                fieldLabel={fieldLabel}
+                pValue={pValue}
+                titleSingular={titleSingular}
+            />
+            <input
+                disabled={disabled}
+                placeholder={isSafari ? "jjjj-mm-dd" : "dd-mm-jjjj"}
+                value={fieldValue ? fieldValue : ""}
+                onChange={handleChange}
+                name={dataObjectProperty}
+                className="block w-full px-4 py-3 leading-tight text-gray-700 border border-gray-400 rounded appearance-none focus:border-gray-500 hover:border-gray-500 focus:outline-none focus:bg-white"
+                type="date"
+                id={`form-field-${titleSingular.toLowerCase()}-${dataObjectProperty.toLowerCase()}`}
+                data-testid={`form-field-${titleSingular.toLowerCase()}-${dataObjectProperty.toLowerCase()}`}
+            />
+        </div>
+    )
+}
+
+/**
+ * Function to set the EindGeldigheid based on user input.
+ *
+ * @param {boolean} hideToggleUitwerkingstrede - Parameter that is used within this function in the conditional operator and if set false, will show the Uitwerkingstrede element.
+ * @param {function} toggleUitwerkingTreding - Parameter that is used within this function as a onClick function and in the FormFieldGeldigheid class to set (toggle) the state of toonUitwerkingTreding.
+ * @param {string} toonUitwerkingTreding - Parameter that is used within this function in a conditional operator to show/hide text and its state is set (toggled) within the FormFieldGeldigheid class.
+ * @param {string} dataObjectProperty - Parameter that may contain the string 'Eind_Geldigheid' and is used within this function to assign the dataObjectProperty variable for the imported FormFieldTitelEnBeschrijving and is used to assign the name and part of the id variable for the input element.
+ * @param {string} fieldLabel - Parameter that is used within this function to assign the fieldLabel variable in the imported FormFieldTitelEnBeschrijving component.
+ * @param {string} pValue - Parameter that is used within this function to assign the pValue variable in the imported FormFieldTitelEnBeschrijving component.
+ * @param {string} titleSingular - Parameter that is used within this function to assign the titleSingular variable for the imported FormFieldTitelEnBeschrijving and is used as part of the id in a conditional operator for the input element.
+ * @param {string} fieldValue - Parameter that is used within this function in a conditional operator to set the value to the value variable of the input element.
+ * @param {boolean} handleChange - Parameter that is used within this function to set the onChange variable to true if the input element has been changed.
+ * @param {boolean} disabled -  Parameter that is used within this function and in the imported FormFieldTitelEnBeschrijving to set the disabled variable, if set true, the input and/or imported FormFieldTitelEnBeschrijving will be disabled.
+ */
+function EindGeldigheid({
+    hideToggleUitwerkingstrede,
+    toggleUitwerkingTreding,
+    toonUitwerkingTreding,
+    dataObjectProperty,
+    fieldLabel,
+    pValue,
+    titleSingular,
+    fieldValue,
+    handleChange,
+    disabled,
+}) {
+    return (
+        <div className="w-full px-3 mb-6">
+            {hideToggleUitwerkingstrede ? null : (
+                <span
+                    className="block w-full mb-6 text-sm text-gray-700 underline cursor-pointer select-none"
+                    id="toggle-uitwerkingtreding"
+                    onClick={toggleUitwerkingTreding}
+                >
+                    {toonUitwerkingTreding ? "Verberg" : "Toon"} veld voor
+                    uitwerkingtreding
+                </span>
+            )}
+
+            {toonUitwerkingTreding ? (
+                <div className="mb-6">
+                    <FormFieldTitelEnBeschrijving
+                        dataObjectProperty={dataObjectProperty}
+                        fieldLabel={fieldLabel}
+                        pValue={pValue}
+                        titleSingular={titleSingular}
+                        disabled={disabled}
+                    />
+                    <input
+                        disabled={disabled}
+                        value={fieldValue ? fieldValue : ""}
+                        onChange={handleChange}
+                        name={dataObjectProperty}
+                        placeholder={isSafari ? "jjjj-mm-dd" : "dd-mm-jjjj"}
+                        className="block w-full px-4 py-3 leading-tight text-gray-700 border border-gray-400 rounded appearance-none focus:border-gray-500 hover:border-gray-500 focus:outline-none focus:bg-white"
+                        type="date"
+                        id={`form-field-${titleSingular.toLowerCase()}-${dataObjectProperty.toLowerCase()}`}
+                        data-testid={`form-field-${titleSingular.toLowerCase()}-${dataObjectProperty.toLowerCase()}`}
+                    />
+                </div>
+            ) : null}
+        </div>
+    )
+}
+
+export default FormFieldGeldigheid

--- a/src/components/FormFieldGeldigheid/FormFieldGeldigheid.test.js
+++ b/src/components/FormFieldGeldigheid/FormFieldGeldigheid.test.js
@@ -1,0 +1,78 @@
+import { render, screen, fireEvent } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import React from "react"
+import FormFieldGeldigheid from "./FormFieldGeldigheid"
+
+const ParentWrapper = ({ children, initEmpty }) => {
+    const [fieldValue, setFieldValue] = React.useState(
+        initEmpty ? null : "2020-12-12"
+    )
+
+    const handleChange = jest.fn((e) => {
+        setFieldValue(e.target.value)
+    })
+
+    return (
+        <div>
+            {React.cloneElement(children, {
+                fieldValue: fieldValue,
+                handleChange: handleChange,
+            })}
+        </div>
+    )
+}
+
+describe("FormFieldGeldigheid", () => {
+    const setup = (props = {}) => {
+        const { initEmpty, disabled, fieldLabel, property } = props
+
+        render(
+            <ParentWrapper initEmpty={initEmpty}>
+                <FormFieldGeldigheid
+                    disabled={disabled}
+                    hideToggleUitwerkingstrede={false}
+                    dataObjectProperty={property ? property : "Eind_Geldigheid"}
+                    fieldLabel="Label"
+                    titleSingular="Titel"
+                />
+            </ParentWrapper>
+        )
+
+        const testid = !property
+            ? `form-field-titel-eind_geldigheid`
+            : `form-field-titel-${property.toLowerCase()}`
+
+        const input = screen.getByTestId(testid)
+        return { fieldLabel, input }
+    }
+
+    it("should render with Eind_Geldigheid", () => {
+        const { input } = setup({ property: "Eind_Geldigheid" })
+        expect(input).toBeInTheDocument()
+    })
+
+    it("should render with Begin_Geldigheid", () => {
+        const { input } = setup({ property: "Begin_Geldigheid" })
+        expect(input).toBeInTheDocument()
+    })
+
+    it("should have the provided value as value", () => {
+        const { input } = setup()
+        expect(input).toHaveValue("2020-12-12")
+    })
+
+    it("should be editable by the user", () => {
+        const { input } = setup()
+        fireEvent.change(input, { target: { value: "2021-10-10" } })
+        expect(input).toHaveValue("2021-10-10")
+    })
+
+    it("user can toggle uitwerkingtreding date", () => {
+        const { input } = setup()
+        const toggle = screen.getByText("Verberg veld voor uitwerkingtreding")
+        expect(toggle).toBeInTheDocument()
+        expect(input).toBeInTheDocument()
+        fireEvent.click(toggle)
+        expect(input).not.toBeInTheDocument()
+    })
+})

--- a/src/components/FormFieldGeldigheid/index.js
+++ b/src/components/FormFieldGeldigheid/index.js
@@ -1,0 +1,3 @@
+import FormFieldGeldigheid from "./FormFieldGeldigheid.js"
+
+export default FormFieldGeldigheid

--- a/src/components/FormFieldsExport/index.js
+++ b/src/components/FormFieldsExport/index.js
@@ -1,3 +1,4 @@
+import FormFieldGeldigheid from "../FormFieldGeldigheid"
 import FormFieldDate from "../FormFieldDate"
 import FormFieldSelect from "../FormFieldSelect"
 import FormFieldSelectBeleidskeuze from "../FormFieldSelectBeleidskeuze"
@@ -15,6 +16,7 @@ import FormFieldRichTextEditor from "../FormFieldRichTextEditor"
 import FormFieldInputContainer from "../FormFieldInputContainer"
 
 export {
+    FormFieldGeldigheid,
     FormFieldDate,
     FormFieldSelect,
     FormFieldSelectBeleidskeuze,

--- a/src/constants/beleidsmodules.js
+++ b/src/constants/beleidsmodules.js
@@ -1,4 +1,4 @@
-import { currentDateFormatted } from "./testValues"
+import { currentDateFormatted, currentDate } from "./testValues"
 
 export const TITLE_SINGULAR = "Beleidsmodule"
 export const TITLE_SINGULAR_PREFIX = "de"
@@ -14,5 +14,12 @@ export const CRUD_PROPERTIES = {
         requiredMessage: "Vul een titel in",
         testValue: `Test beleidsdoel ${currentDateFormatted}`,
         type: "text input",
+    },
+    Besluit_Datum: {
+        initValue: null,
+        required: false,
+        requiredMessage: "",
+        testValue: currentDate,
+        type: "date input",
     },
 }

--- a/src/pages/MuteerBeleidsrelatiesCRUD/ContainerCrudFields/ContainerCrudFields.js
+++ b/src/pages/MuteerBeleidsrelatiesCRUD/ContainerCrudFields/ContainerCrudFields.js
@@ -7,7 +7,7 @@ import APIcontext from "./../APIContext"
 import ContainerMain from "./../../../components/ContainerMain"
 import ContainerFormSection from "./../../../components/ContainerFormSection"
 import FormFieldTextArea from "./../../../components/FormFieldTextArea"
-import FormFieldDate from "./../../../components/FormFieldDate"
+import FormFieldGeldigheid from "./../../../components/FormFieldGeldigheid"
 import FormFieldSelectBeleidskeuze from "./../../../components/FormFieldSelectBeleidskeuze"
 
 class ContainerCrudFields extends React.Component {
@@ -71,7 +71,7 @@ class ContainerCrudFields extends React.Component {
                                             {/* Begin Geldigheid */}
                                             {crudObject["Begin_Geldigheid"] !==
                                             undefined ? (
-                                                <FormFieldDate
+                                                <FormFieldGeldigheid
                                                     handleChange={
                                                         this.context
                                                             .handleChange
@@ -93,7 +93,7 @@ class ContainerCrudFields extends React.Component {
                                             {/* Eind Geldigheid */}
                                             {crudObject["Eind_Geldigheid"] !==
                                             undefined ? (
-                                                <FormFieldDate
+                                                <FormFieldGeldigheid
                                                     openUitwerkingstrede={true}
                                                     hideToggleUitwerkingstrede={
                                                         true

--- a/src/pages/MuteerUniversalObjectCRUD/FormFieldContainers/FormFieldContainerAmbities/FormFieldContainerAmbities.js
+++ b/src/pages/MuteerUniversalObjectCRUD/FormFieldContainers/FormFieldContainerAmbities/FormFieldContainerAmbities.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types"
 
 import ContainerFormSection from "./../../../../components/ContainerFormSection"
 import {
-    FormFieldDate,
+    FormFieldGeldigheid,
     FormFieldTextInput,
     FormFieldTextArea,
     FormFieldWeblink,
@@ -58,7 +58,7 @@ function FormFieldContainerAmbities({
                 />
 
                 <div className="flex flex-wrap -mx-3">
-                    <FormFieldDate
+                    <FormFieldGeldigheid
                         handleChange={handleChange}
                         dataObjectProperty="Begin_Geldigheid"
                         fieldValue={crudObject["Begin_Geldigheid"]}
@@ -67,7 +67,7 @@ function FormFieldContainerAmbities({
                         titleSingular={titleSingular}
                     />
 
-                    <FormFieldDate
+                    <FormFieldGeldigheid
                         openUitwerkingstrede={true}
                         handleChange={handleChange}
                         dataObjectProperty="Eind_Geldigheid"

--- a/src/pages/MuteerUniversalObjectCRUD/FormFieldContainers/FormFieldContainerBelangen/FormFieldContainerBelangen.js
+++ b/src/pages/MuteerUniversalObjectCRUD/FormFieldContainers/FormFieldContainerBelangen/FormFieldContainerBelangen.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types"
 
 import ContainerFormSection from "./../../../../components/ContainerFormSection"
 import {
-    FormFieldDate,
+    FormFieldGeldigheid,
     FormFieldTextInput,
     FormFieldTextArea,
     FormFieldWeblink,
@@ -74,7 +74,7 @@ function FormFieldContainerBelangen({
                 />
 
                 <div className="flex flex-wrap -mx-3">
-                    <FormFieldDate
+                    <FormFieldGeldigheid
                         handleChange={handleChange}
                         fieldValue={crudObject["Begin_Geldigheid"]}
                         fieldLabel="Inwerkingtreding"
@@ -83,7 +83,7 @@ function FormFieldContainerBelangen({
                         titleSingular={titleSingular}
                     />
 
-                    <FormFieldDate
+                    <FormFieldGeldigheid
                         openUitwerkingstrede={true}
                         handleChange={handleChange}
                         Begin_Geldigheid={crudObject["Begin_Geldigheid"]}

--- a/src/pages/MuteerUniversalObjectCRUD/FormFieldContainers/FormFieldContainerBeleidsdoelen/FormFieldContainerBeleidsdoelen.js
+++ b/src/pages/MuteerUniversalObjectCRUD/FormFieldContainers/FormFieldContainerBeleidsdoelen/FormFieldContainerBeleidsdoelen.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types"
 
 import ContainerFormSection from "../../../../components/ContainerFormSection"
 import {
-    FormFieldDate,
+    FormFieldGeldigheid,
     FormFieldTextInput,
     FormFieldTextArea,
     FormFieldWeblink,
@@ -58,7 +58,7 @@ function FormFieldContainerBeleidsdoelen({
                 />
 
                 <div className="flex flex-wrap -mx-3">
-                    <FormFieldDate
+                    <FormFieldGeldigheid
                         handleChange={handleChange}
                         fieldValue={crudObject["Begin_Geldigheid"]}
                         fieldLabel="Inwerkingtreding"
@@ -67,7 +67,7 @@ function FormFieldContainerBeleidsdoelen({
                         titleSingular={titleSingular}
                     />
 
-                    <FormFieldDate
+                    <FormFieldGeldigheid
                         openUitwerkingstrede={true}
                         handleChange={handleChange}
                         fieldValue={crudObject["Eind_Geldigheid"]}

--- a/src/pages/MuteerUniversalObjectCRUD/FormFieldContainers/FormFieldContainerBeleidskeuzes/FormFieldContainerBeleidskeuzes.js
+++ b/src/pages/MuteerUniversalObjectCRUD/FormFieldContainers/FormFieldContainerBeleidskeuzes/FormFieldContainerBeleidskeuzes.js
@@ -5,7 +5,7 @@ import clonedeep from "lodash.clonedeep"
 import ContainerFormSection from "../../../../components/ContainerFormSection"
 import FormFieldTitelEnBeschrijving from "./../../../../components/FormFieldTitelEnBeschrijving"
 import {
-    FormFieldDate,
+    FormFieldGeldigheid,
     FormFieldInputContainer,
     FormFieldTextInput,
     FormFieldTextArea,
@@ -245,7 +245,7 @@ function FormFieldContainerBeleidskeuzes({
                 />
 
                 <div className="flex flex-wrap -mx-3">
-                    <FormFieldDate
+                    <FormFieldGeldigheid
                         disabled={isVigerend}
                         handleChange={handleChange}
                         fieldValue={crudObject["Begin_Geldigheid"]}
@@ -255,7 +255,7 @@ function FormFieldContainerBeleidskeuzes({
                         pValue="Indien bekend, kan hier de datum van inwerkingtreding worden ingevuld"
                         titleSingular={titleSingular}
                     />
-                    <FormFieldDate
+                    <FormFieldGeldigheid
                         disabled={isVigerend}
                         handleChange={handleChange}
                         notRequired={true}

--- a/src/pages/MuteerUniversalObjectCRUD/FormFieldContainers/FormFieldContainerBeleidsmodules/FormFieldContainerBeleidsmodules.js
+++ b/src/pages/MuteerUniversalObjectCRUD/FormFieldContainers/FormFieldContainerBeleidsmodules/FormFieldContainerBeleidsmodules.js
@@ -1,6 +1,9 @@
 import React from "react"
 import ContainerFormSection from "./../../../../components/ContainerFormSection"
-import { FormFieldTextInput } from "./../../../../components/FormFieldsExport"
+import {
+    FormFieldTextInput,
+    FormFieldDate,
+} from "./../../../../components/FormFieldsExport"
 
 function FormFieldContainerBeleidsmodules({
     titleSingular,
@@ -19,6 +22,14 @@ function FormFieldContainerBeleidsmodules({
                     dataObjectProperty="Titel"
                     fieldLabel="Titel"
                     pValue="Formuleer in enkele woorden de titel van deze module."
+                    titleSingular={titleSingular}
+                />
+                <FormFieldDate
+                    handleChange={handleChange}
+                    fieldValue={crudObject["Besluit_Datum"]}
+                    dataObjectProperty="Besluit_Datum"
+                    fieldLabel="Besluit Datum"
+                    pValue="Vul hier de besluit datum in."
                     titleSingular={titleSingular}
                 />
             </ContainerFormSection>

--- a/src/pages/MuteerUniversalObjectCRUD/FormFieldContainers/FormFieldContainerBeleidsprestaties/FormFieldContainerBeleidsprestaties.js
+++ b/src/pages/MuteerUniversalObjectCRUD/FormFieldContainers/FormFieldContainerBeleidsprestaties/FormFieldContainerBeleidsprestaties.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types"
 
 import ContainerFormSection from "./../../../../components/ContainerFormSection"
 import {
-    FormFieldDate,
+    FormFieldGeldigheid,
     FormFieldTextInput,
     FormFieldTextArea,
     FormFieldWeblink,
@@ -58,7 +58,7 @@ function FormFieldContainerBeleidsprestaties({
                 />
 
                 <div className="flex flex-wrap -mx-3">
-                    <FormFieldDate
+                    <FormFieldGeldigheid
                         handleChange={handleChange}
                         dataObjectProperty="Begin_Geldigheid"
                         fieldValue={crudObject["Begin_Geldigheid"]}
@@ -67,7 +67,7 @@ function FormFieldContainerBeleidsprestaties({
                         titleSingular={titleSingular}
                     />
 
-                    <FormFieldDate
+                    <FormFieldGeldigheid
                         openUitwerkingstrede={true}
                         handleChange={handleChange}
                         dataObjectProperty="Eind_Geldigheid"

--- a/src/pages/MuteerUniversalObjectCRUD/FormFieldContainers/FormFieldContainerBeleidsregels/FormFieldContainerBeleidsregels.js
+++ b/src/pages/MuteerUniversalObjectCRUD/FormFieldContainers/FormFieldContainerBeleidsregels/FormFieldContainerBeleidsregels.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types"
 
 import ContainerFormSection from "./../../../../components/ContainerFormSection"
 import {
-    FormFieldDate,
+    FormFieldGeldigheid,
     FormFieldTextInput,
     FormFieldTextArea,
     FormFieldWeblink,
@@ -67,7 +67,7 @@ function FormFieldContainerBeleidsregels({
                 />
 
                 <div className="flex flex-wrap -mx-3">
-                    <FormFieldDate
+                    <FormFieldGeldigheid
                         handleChange={handleChange}
                         fieldValue={crudObject["Begin_Geldigheid"]}
                         fieldLabel="Inwerkingtreding"
@@ -76,7 +76,7 @@ function FormFieldContainerBeleidsregels({
                         titleSingular={titleSingular}
                     />
 
-                    <FormFieldDate
+                    <FormFieldGeldigheid
                         openUitwerkingstrede={true}
                         handleChange={handleChange}
                         fieldValue={crudObject["Eind_Geldigheid"]}

--- a/src/pages/MuteerUniversalObjectCRUD/FormFieldContainers/FormFieldContainerMaatregelen/FormFieldContainerMaatregelen.js
+++ b/src/pages/MuteerUniversalObjectCRUD/FormFieldContainers/FormFieldContainerMaatregelen/FormFieldContainerMaatregelen.js
@@ -4,7 +4,7 @@ import PropTypes from "prop-types"
 import ContainerFormSection from "./../../../../components/ContainerFormSection"
 import FormFieldTitelEnBeschrijving from "./../../../../components/FormFieldTitelEnBeschrijving"
 import {
-    FormFieldDate,
+    FormFieldGeldigheid,
     FormFieldTextInput,
     FormFieldWeblink,
     FormFieldWerkingsgebied,
@@ -144,7 +144,7 @@ function FormFieldContainerMaatregelen({
                     />
 
                     <div className="flex flex-wrap -mx-3">
-                        <FormFieldDate
+                        <FormFieldGeldigheid
                             disabled={isVigerend}
                             handleChange={handleChange}
                             fieldValue={crudObject["Begin_Geldigheid"]}
@@ -154,7 +154,7 @@ function FormFieldContainerMaatregelen({
                             titleSingular={titleSingular}
                         />
 
-                        <FormFieldDate
+                        <FormFieldGeldigheid
                             disabled={isVigerend}
                             openUitwerkingstrede={true}
                             handleChange={handleChange}

--- a/src/pages/MuteerUniversalObjectCRUD/FormFieldContainers/FormFieldContainerThemas/FormFieldContainerThemas.js
+++ b/src/pages/MuteerUniversalObjectCRUD/FormFieldContainers/FormFieldContainerThemas/FormFieldContainerThemas.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types"
 
 import ContainerFormSection from "./../../../../components/ContainerFormSection"
 import {
-    FormFieldDate,
+    FormFieldGeldigheid,
     FormFieldTextInput,
     FormFieldTextArea,
     FormFieldWeblink,
@@ -53,7 +53,7 @@ function FormFieldContainerThemas({ titleSingular, crudObject, handleChange }) {
                     titleSingular={titleSingular}
                 />
                 <div className="flex flex-wrap -mx-3">
-                    <FormFieldDate
+                    <FormFieldGeldigheid
                         handleChange={handleChange}
                         fieldValue={crudObject["Begin_Geldigheid"]}
                         fieldLabel="Inwerkingtreding"
@@ -61,7 +61,7 @@ function FormFieldContainerThemas({ titleSingular, crudObject, handleChange }) {
                         pValue="Indien bekend, kan hier de datum van inwerkingtreding worden ingevuld"
                         titleSingular={titleSingular}
                     />
-                    <FormFieldDate
+                    <FormFieldGeldigheid
                         openUitwerkingstrede={true}
                         handleChange={handleChange}
                         fieldValue={crudObject["Eind_Geldigheid"]}

--- a/src/pages/MuteerVerordeningenStructuurCRUD/ContainerCrudFields/ContainerCrudFields.js
+++ b/src/pages/MuteerVerordeningenStructuurCRUD/ContainerCrudFields/ContainerCrudFields.js
@@ -8,7 +8,7 @@ import APIcontext from "./../APIContext"
 import ContainerMain from "./../../../components/ContainerMain"
 import ContainerFormSection from "./../../../components/ContainerFormSection"
 import FormFieldTextInput from "./../../../components/FormFieldTextInput"
-import FormFieldDate from "./../../../components/FormFieldDate"
+import FormFieldGeldigheid from "./../../../components/FormFieldGeldigheid"
 
 // Import Form Fields
 import FormFields from "./../../../components/FormFieldsExport"
@@ -45,7 +45,7 @@ class ContainerCrudFields extends React.Component {
                                 {/* Geldigheid */}
                                 <div className="flex flex-wrap -mx-3">
                                     {/* Begin Geldigheid */}
-                                    <FormFieldDate
+                                    <FormFieldGeldigheid
                                         handleChange={this.context.handleChange}
                                         fieldValue={
                                             crudObject["Begin_Geldigheid"]
@@ -60,7 +60,7 @@ class ContainerCrudFields extends React.Component {
 
                                     {/* Eind Geldigheid */}
 
-                                    <FormFieldDate
+                                    <FormFieldGeldigheid
                                         handleChange={this.context.handleChange}
                                         notRequired={true}
                                         fieldValue={

--- a/src/pages/MuteerVerordeningenStructuurCRUD/MuteerVerordeningenStructuurCRUD.js
+++ b/src/pages/MuteerVerordeningenStructuurCRUD/MuteerVerordeningenStructuurCRUD.js
@@ -11,7 +11,7 @@ import ContainerFormSection from "./../../components/ContainerFormSection"
 import FormFieldTextInput from "./../../components/FormFieldTextInput"
 import ButtonBackToPage from "./../../components/ButtonBackToPage"
 import LoaderContent from "./../../components/LoaderContent"
-import FormFieldDate from "./../../components/FormFieldDate"
+import FormFieldGeldigheid from "./../../components/FormFieldGeldigheid"
 
 // Import Axios instance to connect with the API
 import axios from "./../../API/axios"
@@ -40,8 +40,9 @@ class MuteerVerordeningenStructuurCRUD extends Component {
         this.voegKoppelingRelatieToe = this.voegKoppelingRelatieToe.bind(this)
         this.createAndSetCrudObject = this.createAndSetCrudObject.bind(this)
         this.wijzigKoppelingRelatie = this.wijzigKoppelingRelatie.bind(this)
-        this.verwijderKoppelingRelatieToe =
-            this.verwijderKoppelingRelatieToe.bind(this)
+        this.verwijderKoppelingRelatieToe = this.verwijderKoppelingRelatieToe.bind(
+            this
+        )
         this.formatGeldigheidDatesForUI = formatGeldigheidDatesForUI.bind(this)
     }
 
@@ -112,12 +113,11 @@ class MuteerVerordeningenStructuurCRUD extends Component {
             crudObject.Eind_Geldigheid = new Date(crudObject.Eind_Geldigheid)
         }
 
-        const containsRequiredUnfilledField =
-            checkContainsRequiredUnfilledField(
-                crudObject,
-                dimensieConstants,
-                titleSingular
-            )
+        const containsRequiredUnfilledField = checkContainsRequiredUnfilledField(
+            crudObject,
+            dimensieConstants,
+            titleSingular
+        )
         if (containsRequiredUnfilledField) {
             this.setState({
                 crudObject: this.formatGeldigheidDatesForUI(crudObject),
@@ -194,8 +194,9 @@ class MuteerVerordeningenStructuurCRUD extends Component {
         const index = nieuwCrudObject[koppelingObject.propertyName].findIndex(
             (item) => item.UUID === koppelingObject.item.UUID
         )
-        nieuwCrudObject[koppelingObject.propertyName][index].Omschrijving =
-            nieuweOmschrijving
+        nieuwCrudObject[koppelingObject.propertyName][
+            index
+        ].Omschrijving = nieuweOmschrijving
 
         this.setState(
             {
@@ -339,7 +340,7 @@ class MuteerVerordeningenStructuurCRUD extends Component {
                                         {/* Geldigheid */}
                                         <div className="flex flex-wrap -mx-3">
                                             {/* Begin Geldigheid */}
-                                            <FormFieldDate
+                                            <FormFieldGeldigheid
                                                 handleChange={handleChange}
                                                 fieldValue={
                                                     crudObject[
@@ -356,7 +357,7 @@ class MuteerVerordeningenStructuurCRUD extends Component {
 
                                             {/* Eind Geldigheid */}
 
-                                            <FormFieldDate
+                                            <FormFieldGeldigheid
                                                 handleChange={handleChange}
                                                 notRequired={true}
                                                 fieldValue={

--- a/src/pages/MuteerVerordeningenstructuurDetail/ContainerCrudFields/Afdeling/Afdeling.js
+++ b/src/pages/MuteerVerordeningenstructuurDetail/ContainerCrudFields/Afdeling/Afdeling.js
@@ -11,7 +11,7 @@ import ContainerFormSection from "./../../../../components/ContainerFormSection"
 // Import Form Fields
 import {
     FormFieldTextInput,
-    FormFieldDate,
+    FormFieldGeldigheid,
 } from "./../../../../components/FormFieldsExport"
 
 import ButtonSubmitFixed from "./../../../../components/ButtonSubmitFixed"
@@ -56,7 +56,7 @@ function Afdeling() {
                             {/* Geldigheid */}
                             <div className="flex flex-wrap -mx-3">
                                 {/* Begin Geldigheid */}
-                                <FormFieldDate
+                                <FormFieldGeldigheid
                                     handleChange={context.handleChange}
                                     fieldValue={crudObject["Begin_Geldigheid"]}
                                     fieldLabel="Datum inwerkingtreding"
@@ -68,7 +68,7 @@ function Afdeling() {
 
                                 {/* Eind Geldigheid */}
 
-                                <FormFieldDate
+                                <FormFieldGeldigheid
                                     handleChange={context.handleChange}
                                     notRequired={true}
                                     fieldValue={crudObject["Eind_Geldigheid"]}

--- a/src/pages/MuteerVerordeningenstructuurDetail/ContainerCrudFields/Paragraaf/Paragraaf.js
+++ b/src/pages/MuteerVerordeningenstructuurDetail/ContainerCrudFields/Paragraaf/Paragraaf.js
@@ -11,7 +11,7 @@ import ContainerFormSection from "./../../../../components/ContainerFormSection"
 // Import Form Fields
 import {
     FormFieldTextInput,
-    FormFieldDate,
+    FormFieldGeldigheid,
 } from "./../../../../components/FormFieldsExport"
 
 import ButtonSubmitFixed from "./../../../../components/ButtonSubmitFixed"
@@ -56,7 +56,7 @@ function Paragraaf() {
                             {/* Geldigheid */}
                             <div className="flex flex-wrap -mx-3">
                                 {/* Begin Geldigheid */}
-                                <FormFieldDate
+                                <FormFieldGeldigheid
                                     handleChange={context.handleChange}
                                     fieldValue={crudObject["Begin_Geldigheid"]}
                                     fieldLabel="Datum inwerkingtreding"
@@ -68,7 +68,7 @@ function Paragraaf() {
 
                                 {/* Eind Geldigheid */}
 
-                                <FormFieldDate
+                                <FormFieldGeldigheid
                                     handleChange={context.handleChange}
                                     notRequired={true}
                                     fieldValue={crudObject["Eind_Geldigheid"]}

--- a/src/utils/formatGeldigheidDatesForAPI.js
+++ b/src/utils/formatGeldigheidDatesForAPI.js
@@ -1,27 +1,48 @@
-// This function creates new Date objects for the formatted date properties of a crudObject.
-// If there is no date value
-
+/**
+ * This function formats the dates from the UI format (yyyy/mm/dd) to a valid datetime for the API
+ * @param {object} crudObject - Contains the object we want to POST/PATCH to the API
+ */
 function formatGeldigheidDatesForAPI(crudObject) {
-    if (
-        crudObject.Begin_Geldigheid !== null &&
-        crudObject.Begin_Geldigheid !== ""
-    ) {
-        crudObject.Begin_Geldigheid = new Date(crudObject.Begin_Geldigheid)
-    } else if (crudObject.Begin_Geldigheid === "") {
-        crudObject.Begin_Geldigheid = null
-    } else {
-        delete crudObject.Begin_Geldigheid
+    /** Format Begin_Geldigheid */
+    if (crudObject.hasOwnProperty("Begin_Geldigheid")) {
+        if (
+            crudObject.Begin_Geldigheid !== null &&
+            crudObject.Begin_Geldigheid !== ""
+        ) {
+            crudObject.Begin_Geldigheid = new Date(crudObject.Begin_Geldigheid)
+        } else if (crudObject.Begin_Geldigheid === "") {
+            crudObject.Begin_Geldigheid = null
+        } else {
+            delete crudObject.Begin_Geldigheid
+        }
     }
 
-    if (
-        crudObject.Eind_Geldigheid !== null &&
-        crudObject.Eind_Geldigheid !== ""
-    ) {
-        crudObject.Eind_Geldigheid = new Date(crudObject.Eind_Geldigheid)
-    } else if (crudObject.Eind_Geldigheid === "") {
-        crudObject.Eind_Geldigheid = null
-    } else {
-        delete crudObject.Eind_Geldigheid
+    /** Format Eind_Geldigheid */
+    if (crudObject.hasOwnProperty("Eind_Geldigheid")) {
+        if (
+            crudObject.Eind_Geldigheid !== null &&
+            crudObject.Eind_Geldigheid !== ""
+        ) {
+            crudObject.Eind_Geldigheid = new Date(crudObject.Eind_Geldigheid)
+        } else if (crudObject.Eind_Geldigheid === "") {
+            crudObject.Eind_Geldigheid = null
+        } else {
+            delete crudObject.Eind_Geldigheid
+        }
+    }
+
+    /** Format Besluit_Datum */
+    if (crudObject.hasOwnProperty("Besluit_Datum")) {
+        if (
+            crudObject.Besluit_Datum !== null &&
+            crudObject.Besluit_Datum !== ""
+        ) {
+            crudObject.Besluit_Datum = new Date(crudObject.Besluit_Datum)
+        } else if (crudObject.Besluit_Datum === "") {
+            crudObject.Besluit_Datum = null
+        } else {
+            delete crudObject.Besluit_Datum
+        }
     }
 
     return crudObject

--- a/src/utils/formatGeldigheidDatesForUI.js
+++ b/src/utils/formatGeldigheidDatesForUI.js
@@ -8,17 +8,12 @@ import { format, isValid } from "date-fns"
 function formatGeldigheidDatesForUI(crudObject) {
     if (!crudObject) return
 
+    /** Format Begin_Geldigheid */
     const beginGeldigheidIsValid =
         crudObject.Begin_Geldigheid !== undefined &&
         crudObject.Begin_Geldigheid !== null &&
         isValid(new Date(crudObject.Begin_Geldigheid))
 
-    const eindGeldigheidIsValid =
-        crudObject.Eind_Geldigheid !== undefined &&
-        crudObject.Eind_Geldigheid !== null &&
-        isValid(new Date(crudObject.Eind_Geldigheid))
-
-    /** Format Begin_Geldigheid */
     if (beginGeldigheidIsValid) {
         crudObject.Begin_Geldigheid = format(
             new Date(crudObject.Begin_Geldigheid),
@@ -29,6 +24,11 @@ function formatGeldigheidDatesForUI(crudObject) {
     }
 
     /** Format Eind_Geldigheid */
+    const eindGeldigheidIsValid =
+        crudObject.Eind_Geldigheid !== undefined &&
+        crudObject.Eind_Geldigheid !== null &&
+        isValid(new Date(crudObject.Eind_Geldigheid))
+
     if (eindGeldigheidIsValid) {
         crudObject.Eind_Geldigheid = format(
             new Date(crudObject.Eind_Geldigheid),
@@ -36,6 +36,21 @@ function formatGeldigheidDatesForUI(crudObject) {
         )
     } else if (crudObject.Eind_Geldigheid === "Invalid Date") {
         crudObject.Eind_Geldigheid = null
+    }
+
+    /** Format Besluit_Datum */
+    const besluitDatumIsValid =
+        crudObject.Besluit_Datum !== undefined &&
+        crudObject.Besluit_Datum !== null &&
+        isValid(new Date(crudObject.Besluit_Datum))
+
+    if (besluitDatumIsValid) {
+        crudObject.Besluit_Datum = format(
+            new Date(crudObject.Besluit_Datum),
+            "yyyy-MM-dd"
+        )
+    } else if (crudObject.Besluit_Datum === "Invalid Date") {
+        crudObject.Besluit_Datum = null
     }
 
     return crudObject


### PR DESCRIPTION
This pull request adds [Toevoegen Besluit_Datum veld aan beleidsmodules](https://pzh-nl.visualstudio.com/Omgevingsbeleid/_boards/board/t/Omgevingsbeleid%20Team/Stories/?workitem=7938).
It also refactored formFieldDate into a universal date component and separated the FormFieldGeldigheid component.