### PR TITLE
🐛 Fix: Creating a 'Beleidsmodule' fires an error message.

### DIFF
--- a/src/constants/leaflet.js
+++ b/src/constants/leaflet.js
@@ -34,7 +34,7 @@ export const RDCrs = new Proj.CRS("EPSG:28992", RDProj4, {
 export const leafletCenter = [52.176997, 5.2]
 
 export const tileURL =
-    "https://geodata.nationaalgeoregister.nl/tiles/service/wmts/brtachtergrondkaartgrijs/EPSG:28992/{z}/{x}/{y}.png"
+    "https://service.pdok.nl/brt/achtergrondkaart/wmts/v2_0?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=grijs&STYLE=default&FORMAT=image/png&TILEMATRIXSET=EPSG:28992&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}"
 
 export const tileURLSattelite =
     "https://service.pdok.nl/hwh/luchtfotorgb/wmts/v1_0/2020_ortho25/EPSG:28992/{z}/{x}/{y}.png"

--- a/src/pages/MuteerUniversalObjectCRUD/MuteerUniversalObjectCRUD.js
+++ b/src/pages/MuteerUniversalObjectCRUD/MuteerUniversalObjectCRUD.js
@@ -197,6 +197,7 @@ class MuteerUniversalObjectCRUD extends Component {
         }
 
         /** Check if the start date is in a valid range */
+        if (!crudObject.Besluit_Datum) {        
         const [
             startDateIsInValidRange,
             endDateIsInValidRange,
@@ -226,6 +227,7 @@ class MuteerUniversalObjectCRUD extends Component {
             toastNotification({ type: "end date valid range" })
 
             return
+            }
         }
 
         /** Prepare CRUD Object for the API */

--- a/src/pages/MuteerUniversalObjectCRUD/MuteerUniversalObjectCRUD.js
+++ b/src/pages/MuteerUniversalObjectCRUD/MuteerUniversalObjectCRUD.js
@@ -63,12 +63,10 @@ class MuteerUniversalObjectCRUD extends Component {
         this.handleSubmit = this.handleSubmit.bind(this)
         this.voegKoppelingRelatieToe = this.voegKoppelingRelatieToe.bind(this)
         this.wijzigKoppelingRelatie = this.wijzigKoppelingRelatie.bind(this)
-        this.verwijderKoppelingRelatie = this.verwijderKoppelingRelatie.bind(
-            this
-        )
-        this.getAndSetDimensieDataFromApi = this.getAndSetDimensieDataFromApi.bind(
-            this
-        )
+        this.verwijderKoppelingRelatie =
+            this.verwijderKoppelingRelatie.bind(this)
+        this.getAndSetDimensieDataFromApi =
+            this.getAndSetDimensieDataFromApi.bind(this)
     }
 
     /**
@@ -192,41 +190,63 @@ class MuteerUniversalObjectCRUD extends Component {
                 `form-field-${titleSingular.toLowerCase()}-eind_geldigheid`
             )
             toastNotification({ type: "end date before start date" })
-
             return
         }
 
-        /** Check if the start date is in a valid range */
-        if (!crudObject.Besluit_Datum) {        
-        const [
-            startDateIsInValidRange,
-            endDateIsInValidRange,
-        ] = isDateInAValidRange(crudObject)
-
-        const beginGeldigheidIsNotEmpty =
-            crudObject.Begin_Geldigheid !== "1753-01-01" &&
-            crudObject.Begin_Geldigheid !== null &&
-            crudObject.Begin_Geldigheid !== ""
-
-        const eindGeldigheidIsNotEmpty =
-            crudObject.Eind_Geldigheid !== "10000-01-01" &&
-            crudObject.Eind_Geldigheid !== null &&
-            crudObject.Eind_Geldigheid !== ""
-
-        if (!startDateIsInValidRange && beginGeldigheidIsNotEmpty) {
-            scrollToElement(
-                `form-field-${titleSingular.toLowerCase()}-begin_geldigheid`
+        /** Check if the date properties are in a valid range */
+        if (
+            crudObject.hasOwnProperty("Begin_Geldigheid") &&
+            crudObject.hasOwnProperty("Eind_Geldigheid")
+        ) {
+            const startDateIsInValidRange = isDateInAValidRange(
+                new Date(crudObject.Begin_Geldigheid)
             )
-            toastNotification({ type: "start date valid range" })
-
-            return
-        } else if (!endDateIsInValidRange && eindGeldigheidIsNotEmpty) {
-            scrollToElement(
-                `form-field-${titleSingular.toLowerCase()}-eind_geldigheid`
+            const endDateIsInValidRange = isDateInAValidRange(
+                new Date(crudObject.Eind_Geldigheid)
             )
-            toastNotification({ type: "end date valid range" })
 
-            return
+            const beginGeldigheidIsNotEmpty =
+                crudObject.Begin_Geldigheid !== "1753-01-01" &&
+                crudObject.Begin_Geldigheid !== null &&
+                crudObject.Begin_Geldigheid !== ""
+
+            const eindGeldigheidIsNotEmpty =
+                crudObject.Eind_Geldigheid !== "10000-01-01" &&
+                crudObject.Eind_Geldigheid !== null &&
+                crudObject.Eind_Geldigheid !== ""
+
+            if (!startDateIsInValidRange && beginGeldigheidIsNotEmpty) {
+                scrollToElement(
+                    `form-field-${titleSingular.toLowerCase()}-begin_geldigheid`
+                )
+                toastNotification({ type: "start date valid range" })
+
+                return
+            } else if (!endDateIsInValidRange && eindGeldigheidIsNotEmpty) {
+                scrollToElement(
+                    `form-field-${titleSingular.toLowerCase()}-eind_geldigheid`
+                )
+                toastNotification({ type: "end date valid range" })
+
+                return
+            }
+        } else if (crudObject.hasOwnProperty("Besluit_Datum")) {
+            const besluitDatumIsInValidRange = isDateInAValidRange(
+                new Date(crudObject.Besluit_Datum)
+            )
+
+            const besluitDatumIsNotEmpty =
+                crudObject.besluitDatumIsNotEmpty !== "1753-01-01" &&
+                crudObject.besluitDatumIsNotEmpty !== null &&
+                crudObject.besluitDatumIsNotEmpty !== ""
+
+            if (!besluitDatumIsInValidRange && besluitDatumIsNotEmpty) {
+                scrollToElement(
+                    `form-field-${titleSingular.toLowerCase()}-begin_geldigheid`
+                )
+                toastNotification({ type: "start date valid range" })
+
+                return
             }
         }
 
@@ -236,6 +256,9 @@ class MuteerUniversalObjectCRUD extends Component {
 
         /** If the user is editing an existing object we PATCH it, else we POST it to create a new object */
         const typeOfRequest = this.state.edit ? "PATCH" : "POST"
+
+        // console.log("POST PATCH")
+        // return
 
         if (typeOfRequest === "PATCH") {
             crudObject = this.prepareForRequest(crudObject, "patch")

--- a/src/pages/MuteerVerordeningenStructuurCRUD/MuteerVerordeningenStructuurCRUD.js
+++ b/src/pages/MuteerVerordeningenStructuurCRUD/MuteerVerordeningenStructuurCRUD.js
@@ -44,9 +44,8 @@ class MuteerVerordeningenStructuurCRUD extends Component {
         this.voegKoppelingRelatieToe = this.voegKoppelingRelatieToe.bind(this)
         this.createAndSetCrudObject = this.createAndSetCrudObject.bind(this)
         this.wijzigKoppelingRelatie = this.wijzigKoppelingRelatie.bind(this)
-        this.verwijderKoppelingRelatieToe = this.verwijderKoppelingRelatieToe.bind(
-            this
-        )
+        this.verwijderKoppelingRelatieToe =
+            this.verwijderKoppelingRelatieToe.bind(this)
         this.formatGeldigheidDatesForUI = formatGeldigheidDatesForUI.bind(this)
     }
 
@@ -115,10 +114,12 @@ class MuteerVerordeningenStructuurCRUD extends Component {
         }
 
         /** Check if the start date is in a valid range */
-        const [
-            startDateIsInValidRange,
-            endDateIsInValidRange,
-        ] = isDateInAValidRange(crudObject)
+        const startDateIsInValidRange = isDateInAValidRange(
+            new Date(crudObject.Begin_Geldigheid)
+        )
+        const endDateIsInValidRange = isDateInAValidRange(
+            new Date(crudObject.Eind_Geldigheid)
+        )
 
         if (!startDateIsInValidRange) {
             toastNotification({ type: "start date valid range" })
@@ -190,9 +191,8 @@ class MuteerVerordeningenStructuurCRUD extends Component {
         const index = nieuwCrudObject[koppelingObject.propertyName].findIndex(
             (item) => item.UUID === koppelingObject.item.UUID
         )
-        nieuwCrudObject[koppelingObject.propertyName][
-            index
-        ].Omschrijving = nieuweOmschrijving
+        nieuwCrudObject[koppelingObject.propertyName][index].Omschrijving =
+            nieuweOmschrijving
 
         this.setState(
             {

--- a/src/pages/MuteerVerordeningenstructuurDetail/MuteerVerordeningenstructuurDetail.js
+++ b/src/pages/MuteerVerordeningenstructuurDetail/MuteerVerordeningenstructuurDetail.js
@@ -87,10 +87,8 @@ const MuteerVerordeningenstructuurDetail = () => {
     const [UUIDBeingEdited, setUUIDBeingEdited] = React.useState(null)
 
     // [indexArrayToUUIDBeingEdited] - This contains an array the path to the specific item in the lineage. The first item is always the chapter followed by subsequent levels from there.
-    const [
-        indexArrayToUUIDBeingEdited,
-        setIndexArrayToUUIDBeingEdited,
-    ] = React.useState(null)
+    const [indexArrayToUUIDBeingEdited, setIndexArrayToUUIDBeingEdited] =
+        React.useState(null)
 
     // This state value is used to see when we need to Patch the lineage
     // See the useEffect below. We use this useEffect to trigger when a new lineage has set
@@ -112,9 +110,8 @@ const MuteerVerordeningenstructuurDetail = () => {
     }, [lineage])
 
     // [volgnummerBeingEdited] - Contains the property 'volgnummer' of the object that is edited. This is displayed in the Meta edit content menu
-    const [volgnummerBeingEdited, setVolgnummerBeingEdited] = React.useState(
-        null
-    )
+    const [volgnummerBeingEdited, setVolgnummerBeingEdited] =
+        React.useState(null)
 
     // [verordeningsObjectFromGET] - Contains the object we get from the GET request on [UUIDBeingEdited]
     const verordeningsObjectFromGETReducer = (state, action) => {
@@ -151,15 +148,11 @@ const MuteerVerordeningenstructuurDetail = () => {
         }
     }
 
-    const [
-        verordeningsObjectFromGET,
-        setVerordeningsObjectFromGET,
-    ] = React.useReducer(verordeningsObjectFromGETReducer, null)
+    const [verordeningsObjectFromGET, setVerordeningsObjectFromGET] =
+        React.useReducer(verordeningsObjectFromGETReducer, null)
 
-    const [
-        verordeningsObjectIsLoading,
-        setVerordeningsObjectIsLoading,
-    ] = React.useState(false)
+    const [verordeningsObjectIsLoading, setVerordeningsObjectIsLoading] =
+        React.useState(false)
 
     // Loading state for [verordeningsLedenFromGET]
     const [
@@ -198,10 +191,8 @@ const MuteerVerordeningenstructuurDetail = () => {
         }
     }
 
-    const [
-        verordeningsLedenFromGET,
-        setVerordeningsLedenFromGET,
-    ] = React.useReducer(verordeningsLedenFromGETReducer, null)
+    const [verordeningsLedenFromGET, setVerordeningsLedenFromGET] =
+        React.useReducer(verordeningsLedenFromGETReducer, null)
 
     // GET request for [UUIDBeingEdited] to get the whole object, then setInState under [verordeningsObjectFromGET] and set [verordeningsObjectIsLoading] to null
     React.useEffect(() => {
@@ -569,9 +560,8 @@ const MuteerVerordeningenstructuurDetail = () => {
             )
 
             // Save new state
-            currentLineage.Structuur.Children[
-                currentActiveChapter
-            ].Children = reorderedChildren
+            currentLineage.Structuur.Children[currentActiveChapter].Children =
+                reorderedChildren
             setLineage(currentLineage)
         }
 
@@ -705,14 +695,12 @@ const MuteerVerordeningenstructuurDetail = () => {
             }
 
             // Get parent element, parent index and childIndex of the source parent
-            const [
-                sourceParentIndex,
-                sourceChildIndex,
-            ] = findParentElAndIndexes(
-                currentLineage.Structuur.Children[currentActiveChapter]
-                    .Children,
-                sourceParentId
-            )
+            const [sourceParentIndex, sourceChildIndex] =
+                findParentElAndIndexes(
+                    currentLineage.Structuur.Children[currentActiveChapter]
+                        .Children,
+                    sourceParentId
+                )
 
             // Get parent element, parent index and childIndex of the destination parent
             const [destParentIndex, destChildIndex] = findParentElAndIndexes(
@@ -776,9 +764,8 @@ const MuteerVerordeningenstructuurDetail = () => {
                 // Assign reordered Children of the destinitation Array in the currentLineage
                 currentLineage.Structuur.Children[
                     currentActiveChapter
-                ].Children[destParentIndex].Children[
-                    destChildIndex
-                ].Children = destinationParentElChildrenArray
+                ].Children[destParentIndex].Children[destChildIndex].Children =
+                    destinationParentElChildrenArray
 
                 // Save new state
                 setLineage(currentLineage)
@@ -822,6 +809,7 @@ const MuteerVerordeningenstructuurDetail = () => {
             delete object.Created_Date
             delete object.Modified_By
             delete object.Modified_Date
+            delete object.Ref_Beleidskeuzes
             delete object.UUID
             delete object.ID
 
@@ -955,9 +943,8 @@ const MuteerVerordeningenstructuurDetail = () => {
                     break
                 // Paragraaf || Afdeling || Artikel
                 case 2:
-                    newLineage.Structuur.Children[index[0]].Children[
-                        index[1]
-                    ] = strippedObject
+                    newLineage.Structuur.Children[index[0]].Children[index[1]] =
+                        strippedObject
                     break
                 // Afdeling || Artikel
                 case 3:
@@ -981,10 +968,12 @@ const MuteerVerordeningenstructuurDetail = () => {
         }
 
         /** Check if the start date is in a valid range */
-        const [
-            startDateIsInValidRange,
-            endDateIsInValidRange,
-        ] = isDateInAValidRange(verordeningsObjectFromGET)
+        const startDateIsInValidRange = isDateInAValidRange(
+            new Date(verordeningsObjectFromGET.Begin_Geldigheid)
+        )
+        const endDateIsInValidRange = isDateInAValidRange(
+            new Date(verordeningsObjectFromGET.Eind_Geldigheid)
+        )
 
         if (!startDateIsInValidRange) {
             toastNotification({ type: "start date valid range" })
@@ -1161,7 +1150,8 @@ const MuteerVerordeningenstructuurDetail = () => {
         verordeningsObjectIsLoading || verordeningsObjectLedenIsLoading
 
     const context = {
-        verordeningsObjectIsLoading: verordeningsObjectAndPotentialLedenIsLoading,
+        verordeningsObjectIsLoading:
+            verordeningsObjectAndPotentialLedenIsLoading,
         setIndexArrayToUUIDBeingEdited: setIndexArrayToUUIDBeingEdited,
         setVerordeningsObjectFromGET: setVerordeningsObjectFromGET,
         verordeningsObjectFromGET: verordeningsObjectFromGET,

--- a/src/utils/isDateInAValidRange.js
+++ b/src/utils/isDateInAValidRange.js
@@ -2,23 +2,15 @@ import { isBefore, isAfter } from "date-fns"
 
 /**
  * Function to check wether the end validity date and the start validity date are between the year 1900 and 2100
- * @param {object} crudObject - Contains the object with the validity date properties
- * @returns {array} - Containing two boolean values indicating the start and end range validity: [startDateIsInValidRange, endDateIsInValidRange]
+ * @param {object} date - Contains a Date object
+ * @returns boolean - True if it is between the year 1900 and 2100
  */
-const isDateInAValidRange = (crudObject) => {
-    const startDate = new Date(crudObject.Begin_Geldigheid)
-    const endDate = new Date(crudObject.Eind_Geldigheid)
-
+const isDateInAValidRange = (date) => {
     const minimumDate = new Date("1990")
     const maximumDate = new Date("2100")
-
-    const startDateIsInValidRange =
-        isBefore(startDate, maximumDate) && isAfter(startDate, minimumDate)
-
-    const endDateIsInValidRange =
-        isBefore(endDate, maximumDate) && isAfter(endDate, minimumDate)
-
-    return [startDateIsInValidRange, endDateIsInValidRange]
+    const dateIsInValidRange =
+        isBefore(date, maximumDate) && isAfter(date, minimumDate)
+    return dateIsInValidRange
 }
 
 export { isDateInAValidRange }


### PR DESCRIPTION
Added the if statement to check if 'crudobject.Besluit_Datum' is empty, because the two values 'crudObject.Begin_Geldigheid' and 'crudObject.Begin_Geldigheid' are not used and are empty when creating a 'Beleidsmodule', which cause it to wrongfully display the error message "Vul een inwerkingtreding in tussen 1990 en 2100". 

See US 9034 - "Aanmaken Beleidsmodule geeft foutmelding in-en uitwerk tussen 1990 en 2100 weer na opslaan"