### PR TITLE
🐛  ab#9500 - Fix Removed text in revisionoverview

### DIFF
--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -1226,6 +1226,9 @@ mark {
         opacity: 1;
         text-decoration: none !important;
     }
+    p {
+        display: inline;
+    }
 }
 
 #revision-overview-leaflet {


### PR DESCRIPTION
A very exciting PR. Fixes the display of removed text in the revision overview.

**Before**
![CleanShot 2022-01-17 at 11 54 03](https://user-images.githubusercontent.com/9105359/149757242-15cc405e-127c-40ba-b9d9-d82590cf0a65.png)

**After**
![CleanShot 2022-01-17 at 11 54 21](https://user-images.githubusercontent.com/9105359/149757260-0e78260b-abfd-4649-809f-e960997d3a4c.png)