### PR TITLE
AB#35829

### DIFF
--- a/src/components/DynamicObject/DynamicObjectForm/DynamicField/DynamicField.tsx
+++ b/src/components/DynamicObject/DynamicObjectForm/DynamicField/DynamicField.tsx
@@ -132,7 +132,8 @@ const DynamicField = ({
                             setActiveModal('objectAreaAnnotate', { editor })
                         }
                         aria-label="Gebiedsaanwijzing"
-                        title="Gebiedsaanwijzing">
+                        title="Gebiedsaanwijzing"
+                        disabled={isLocked}>
                         <DrawPolygon />
                     </RteMenuButton>,
                 ],

--- a/src/components/Form/FieldAreaAnnotate/FieldAreaAnnotate.tsx
+++ b/src/components/Form/FieldAreaAnnotate/FieldAreaAnnotate.tsx
@@ -58,7 +58,10 @@ const FieldAreaAnnotate = ({
             {...props}
             options={options}
             isLoading={isLoading}
-            disabled={optionType === 'group' ? !values.Ref_Type : undefined}
+            disabled={
+                props.disabled ||
+                (optionType === 'group' ? !values.Ref_Type : undefined)
+            }
             blurInputOnSelect
         />
     )


### PR DESCRIPTION
[Bug 35829](https://dev.azure.com/pzh-nl/Omgevingsbeleid/_workitems/edit/35829): Velden niet inactief bij gelockte module