### PR TITLE
AB#37926 - Leveringen - 'Nieuwe levering maken' mogelijk indien publicatie-levering in afwachting is

### DIFF
--- a/src/components/Modals/PublicationModals/PublicationPackageReportUploadModal/PublicationPackageReportUploadModal.tsx
+++ b/src/components/Modals/PublicationModals/PublicationPackageReportUploadModal/PublicationPackageReportUploadModal.tsx
@@ -19,6 +19,7 @@ import {
     getPublicationAnnouncementPackagesGetListAnnouncementPackagesQueryKey,
     getPublicationAnnouncementReportsGetListAnnnouncementPackageReportsQueryKey,
     getPublicationAnnouncementsGetListAnnouncementsQueryKey,
+    getPublicationEnvironmentsGetDetailEnvironmentQueryKey,
     getPublicationVersionsGetDetailVersionQueryKey,
     usePublicationActReportsGetListActPackageReports,
     usePublicationAnnouncementReportsGetListAnnnouncementPackageReports,
@@ -107,6 +108,20 @@ const PublicationPackageReportUploadModal = () => {
                         queryKey:
                             getPublicationAnnouncementsGetListAnnouncementsQueryKey(),
                         refetchType: 'all',
+                    })
+                }
+
+                if (
+                    (res.Status === 'valid' ||
+                        res.Status === 'failed' ||
+                        res.Status === 'aborted') &&
+                    modalState.packageType === 'publication'
+                ) {
+                    queryClient.invalidateQueries({
+                        queryKey:
+                            getPublicationEnvironmentsGetDetailEnvironmentQueryKey(
+                                modalState.environmentUUID
+                            ),
                     })
                 }
 

--- a/src/components/Modals/types.ts
+++ b/src/components/Modals/types.ts
@@ -113,7 +113,8 @@ export interface ModalStateMap {
         publicationUUID: string
         packageUUID: string
         announcementUUID: string
-        packageType?: PackageType
+        environmentUUID: string
+        packageType: PackageType
     }
     publicationAttachmentDelete: {
         attachment: AttachmentShort

--- a/src/components/Modules/ModuleLock/ModuleLock.tsx
+++ b/src/components/Modules/ModuleLock/ModuleLock.tsx
@@ -1,4 +1,4 @@
-import { cn, Divider, Notification, Text } from '@pzh-ui/components'
+import { cn, Notification, Text } from '@pzh-ui/components'
 import { Lock, LockOpen } from '@pzh-ui/icons'
 import { useParams } from 'react-router-dom'
 
@@ -64,14 +64,11 @@ interface LockedNotificationProps {
 }
 
 export const LockedNotification = ({ isDetail }: LockedNotificationProps) => (
-    <>
-        {!isDetail && <Divider className="mt-3" />}
-        <Notification
-            variant="warning"
-            title="De module is op dit moment gelockt, er kunnen geen wijzigingen worden aangebracht."
-            className={cn('w-full', { 'mt-6': !isDetail })}
-        />
-    </>
+    <Notification
+        variant="warning"
+        title="De module is op dit moment gelockt, er kunnen geen wijzigingen worden aangebracht."
+        className={cn('w-full', { 'mt-6': !isDetail })}
+    />
 )
 
 export default ModuleLock

--- a/src/components/Publications/PublicationPackages/components/Package.tsx
+++ b/src/components/Publications/PublicationPackages/components/Package.tsx
@@ -21,6 +21,7 @@ interface PackageProps extends PublicationPackage {
     publicationUUID: string
     versionUUID: string
     announcementUUID?: string
+    environmentUUID?: string
     isLocked?: boolean
     canPublicate?: boolean
 }
@@ -35,6 +36,7 @@ const Package = ({
     publicationUUID,
     versionUUID,
     announcementUUID,
+    environmentUUID,
     canPublicate,
     Package_Type,
 }: PackageProps) => {
@@ -43,6 +45,7 @@ const Package = ({
 
     const { downloadPackage } = useActions({
         publicationType,
+        packageType: Package_Type as PackageType,
         publicationUUID,
         versionUUID,
         announcementUUID,
@@ -117,6 +120,7 @@ const Package = ({
                                             publicationType,
                                             publicationUUID,
                                             announcementUUID,
+                                            environmentUUID,
                                             packageType:
                                                 Package_Type as PackageType,
                                         }

--- a/src/components/Publications/PublicationPackages/components/Packages.tsx
+++ b/src/components/Publications/PublicationPackages/components/Packages.tsx
@@ -76,9 +76,11 @@ const Packages = ({
 
     const { createPackage } = useActions({
         publicationType,
+        packageType,
         versionUUID: version.UUID,
         announcementUUID: announcement?.UUID,
         publicationUUID: String(publication?.UUID),
+        environmentUUID: environment?.UUID,
     })
 
     return (
@@ -140,13 +142,15 @@ const Packages = ({
                                     publicationUUID={String(publication?.UUID)}
                                     versionUUID={version.UUID}
                                     announcementUUID={announcement?.UUID}
+                                    environmentUUID={environment?.UUID}
                                     canPublicate={environment?.Can_Publicate}
                                     {...item}
                                 />
                             ))}
-                            {(!version.Is_Locked ||
+
+                            {((!version.Is_Locked && !environment?.Is_Locked) ||
                                 (environment?.Is_Locked &&
-                                    packageType === 'publication')) && (
+                                    packageType !== 'publication')) && (
                                 <PackageCreate
                                     createPackage={createPackage}
                                     announcementUUID={announcement?.UUID}

--- a/src/components/Publications/PublicationPackages/components/Report.tsx
+++ b/src/components/Publications/PublicationPackages/components/Report.tsx
@@ -22,14 +22,6 @@ type ReportData =
     | PublicationActPackageReportShort
     | PublicationAnnouncementPackageReportShort
 
-const statusStyles: Record<ReportStatusType, string> = {
-    valid: 'border-pzh-green-500 bg-pzh-green-10 text-pzh-green-500',
-    failed: 'border-pzh-red-500 bg-pzh-red-10',
-    pending: 'border-pzh-blue-500 text-pzh-blue-500',
-    not_applicable: 'border-pzh-blue-500 text-pzh-blue-500',
-    aborted: 'border-pzh-red-500 bg-pzh-red-10 text-pzh-red-500',
-}
-
 const statusIcons: Record<ReportStatusType, React.JSX.Element> = {
     valid: (
         <CircleCheckSolid

--- a/src/components/Publications/PublicationPackages/components/actions.ts
+++ b/src/components/Publications/PublicationPackages/components/actions.ts
@@ -8,6 +8,7 @@ import {
     getPublicationAnnouncementPackagesGetDownloadAnnouncementPackageQueryKey,
     getPublicationAnnouncementPackagesGetListAnnouncementPackagesQueryKey,
     getPublicationAnnouncementReportsGetDownloadAnnouncementPackageReportQueryKey,
+    getPublicationEnvironmentsGetDetailEnvironmentQueryKey,
     getPublicationPackagesGetListUnifiedPackagesQueryKey,
     getPublicationVersionsGetListVersionsQueryKey,
     usePublicationActPackagesPostCreateActPackage,
@@ -15,7 +16,7 @@ import {
     usePublicationAnnouncementPackagesPostCreateAnnouncementPackage,
     usePublicationAnnouncementReportsPostUploadAnnouncementPackageReport,
 } from '@/api/fetchers'
-import { HTTPValidationError } from '@/api/fetchers.schemas'
+import { HTTPValidationError, PackageType } from '@/api/fetchers.schemas'
 import { downloadFile } from '@/utils/file'
 
 import useModalStore from '@/store/modalStore'
@@ -23,20 +24,24 @@ import { PublicationType } from '../../types'
 
 interface ActionsProps {
     publicationType: PublicationType
+    packageType?: PackageType
     versionUUID?: string
     announcementUUID?: string
     publicationUUID: string
     packageUUID?: string
     reportUUID?: string
+    environmentUUID?: string
 }
 
 export const useActions = ({
     publicationType,
+    packageType,
     versionUUID,
     announcementUUID,
     publicationUUID,
     packageUUID,
     reportUUID,
+    environmentUUID,
 }: ActionsProps) => {
     const queryClient = useQueryClient()
     const setActiveModal = useModalStore(state => state.setActiveModal)
@@ -87,6 +92,15 @@ export const useActions = ({
                     refetchType: 'all',
                     exact: false,
                 })
+
+                if (packageType === 'publication' && environmentUUID) {
+                    queryClient.invalidateQueries({
+                        queryKey:
+                            getPublicationEnvironmentsGetDetailEnvironmentQueryKey(
+                                environmentUUID
+                            ),
+                    })
+                }
             },
             onError: (error: AxiosError<HTTPValidationError>) => {
                 if (
@@ -188,6 +202,15 @@ export const useActions = ({
                     refetchType: 'all',
                     exact: false,
                 })
+
+                if (packageType === 'publication' && environmentUUID) {
+                    queryClient.invalidateQueries({
+                        queryKey:
+                            getPublicationEnvironmentsGetDetailEnvironmentQueryKey(
+                                environmentUUID
+                            ),
+                    })
+                }
             },
         },
     })

--- a/src/pages/protected/Modules/ModuleDetail/components/ObjectsTable.tsx
+++ b/src/pages/protected/Modules/ModuleDetail/components/ObjectsTable.tsx
@@ -179,7 +179,7 @@ const ObjectsTableFilters = ({
                             Onderdeel toevoegen
                         </Button>
                     )}
-                    {canEditModule && isModuleManager && (
+                    {(canEditModule || isModuleManager) && (
                         <Button
                             onPress={() => setActiveModal('moduleScan')}
                             variant="secondary"


### PR DESCRIPTION
[Bug 37926](https://dev.azure.com.mcas.ms/pzh-nl/Omgevingsbeleid/_workitems/edit/37926?McasTsid=26110&McasCtx=4): Leveringen - 'Nieuwe levering maken' mogelijk indien publicatie-levering in afwachting is