### PR TITLE
AB#36374 - Onmogelijk maken om een lege gebiedsaanwijzing-annotatie te maken

### DIFF
--- a/src/components/DynamicObject/DynamicObjectForm/DynamicField/extensions/area.ts
+++ b/src/components/DynamicObject/DynamicObjectForm/DynamicField/extensions/area.ts
@@ -80,27 +80,47 @@ export const Area = Mark.create({
             setArea:
                 attributes =>
                 ({ chain, state }) => {
-                    const { empty } = state.selection
+                    const { from, to, empty } = state.selection
+                    const selectedText = state.doc.textBetween(from, to)
+                    const isEmptySelection =
+                        empty || selectedText.trim().length === 0
 
-                    if (empty) {
-                        const { text = 'Locatie', ...rest } = attributes
+                    if (isEmptySelection) {
+                        const {
+                            text,
+                            [AREA_DATA_ATTRS.Cached_Title]: cachedTitle,
+                            ...markAttributes
+                        } = attributes
+
+                        const insertedText =
+                            text ||
+                            (typeof cachedTitle === 'string'
+                                ? cachedTitle
+                                : undefined) ||
+                            'Locatie'
+
                         return chain()
-                            .insertContentAt(state.selection.anchor, [
+                            .insertContentAt(
+                                { from, to },
                                 {
                                     type: 'text',
-                                    text,
+                                    text: insertedText,
                                     marks: [
                                         {
                                             type: this.name,
-                                            attrs: rest,
+                                            attrs: {
+                                                ...markAttributes,
+                                                [AREA_DATA_ATTRS.Cached_Title]:
+                                                    cachedTitle,
+                                            },
                                         },
                                     ],
-                                },
-                            ])
+                                }
+                            )
                             .run()
-                    } else {
-                        return chain().setMark(this.name, attributes).run()
                     }
+
+                    return chain().setMark(this.name, attributes).run()
                 },
         }
     },

--- a/src/utils/removeEmptyInlineTags.ts
+++ b/src/utils/removeEmptyInlineTags.ts
@@ -1,4 +1,4 @@
-const EMPTY_TAG_SELECTOR = 'em, strong, b, i, u, sub, sup'
+const EMPTY_TAG_SELECTOR = 'em, strong, b, i, u, sub, sup, a'
 
 export function isVisuallyEmpty(value: string): boolean {
     return (

--- a/src/validation/zodSchema.ts
+++ b/src/validation/zodSchema.ts
@@ -21,7 +21,7 @@ const HEADING_FOLLOWED_BY_TEXT_ERROR =
     'Een kop moet altijd gevolgd worden door tekst.'
 
 const HEADING_SELECTOR = 'h3, h4, h5'
-const EMPTY_INLINE_TAG_SELECTOR = 'em, strong, b, i, u, li p, sub, sup'
+const EMPTY_INLINE_TAG_SELECTOR = 'em, strong, b, i, u, li p, sub, sup, a'
 const HEADING_TAG_REGEX = /^H[3-5]$/
 
 export const schemaDefaults = {


### PR DESCRIPTION
[User Story 36374](https://dev.azure.com.mcas.ms/pzh-nl/Omgevingsbeleid/_workitems/edit/36374?McasTsid=26110&McasCtx=4): Onmogelijk maken om een lege gebiedsaanwijzing-annotatie te maken