### PR TITLE
AB#38073 - "Gekoppelde documenten" bij een maatregel niet zichtbaar, indien wel zichtbaar niet te openen

### DIFF
--- a/src/components/DynamicObject/ObjectConnectedDocuments/ObjectConnectedDocuments.tsx
+++ b/src/components/DynamicObject/ObjectConnectedDocuments/ObjectConnectedDocuments.tsx
@@ -18,7 +18,7 @@ interface ObjectConnectedDocumentsProps {
 const ObjectConnectedDocuments = ({
     documents,
 }: ObjectConnectedDocumentsProps) => (
-    <>
+    <div className="mb-6 group-has-[div:empty]:hidden">
         <Heading level="3" size="m" className="mb-2">
             Gekoppelde documenten
         </Heading>
@@ -28,7 +28,7 @@ const ObjectConnectedDocuments = ({
                 <Document key={document.Code} {...document} />
             ))}
         </div>
-    </>
+    </div>
 )
 
 const Document = ({ Cached_Title, Object_ID }: ObjectStatics) => {
@@ -49,7 +49,7 @@ const Document = ({ Cached_Title, Object_ID }: ObjectStatics) => {
         query: {
             enabled:
                 (!moduleId && !!Object_ID) ||
-                (!!moduleId && !!Object_ID && !moduleData && isSuccess) ||
+                (!!moduleId && !!Object_ID && !moduleData) ||
                 isError,
         },
     })

--- a/src/components/DynamicObject/ObjectSidebar/ObjectSidebar.tsx
+++ b/src/components/DynamicObject/ObjectSidebar/ObjectSidebar.tsx
@@ -110,14 +110,11 @@ const ObjectSidebar = ({
                     ))}
             </div>
 
-            {!!Documents_Statics?.length &&
-                ((!!user && !!moduleId) || (!user && !moduleId)) && (
-                    <div className="mb-6">
-                        <ObjectConnectedDocuments
-                            documents={Documents_Statics}
-                        />
-                    </div>
-                )}
+            {!!Documents_Statics?.length && (
+                <div className="group">
+                    <ObjectConnectedDocuments documents={Documents_Statics} />
+                </div>
+            )}
 
             {!!user && (
                 <div>

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -36,10 +36,14 @@ export const downloadFile = async (
     openInNewTab = false
 ) => {
     try {
+        const accessToken = getAccessToken()
+
         const response = await fetch(`${getApiUrl()}/${path}`, {
             method: postData ? 'POST' : 'GET',
             headers: {
-                Authorization: `Bearer ${getAccessToken()}`,
+                ...(accessToken && {
+                    Authorization: `Bearer ${accessToken}`,
+                }),
                 'Content-Type': 'application/json',
             },
             ...(postData && { body: JSON.stringify(postData) }),

--- a/src/utils/handleError.ts
+++ b/src/utils/handleError.ts
@@ -33,14 +33,17 @@ const handleError = <T>(err: Error, helpers: FormikHelpers<T>) => {
 }
 
 export const handleFileError = <T>(err: Error, helpers: FormikHelpers<T>) => {
-    Array.isArray(err.data?.detail) &&
-        err.data?.detail?.forEach((item: any) => {
+    if (Array.isArray(err.data?.detail)) {
+        err.data.detail.forEach((item: any) => {
+            const metadataField = KEYS[item.key] ?? item.key
+
+            helpers.setFieldTouched('File', true, false)
             helpers.setFieldError(
                 'File',
-                `Het veld '${KEYS[item.key]}' in de meta-data van het document is gevuld, de waarde hiervan is “${item.value}”`
+                `Het veld '${metadataField}' in de meta-data van het document is gevuld, de waarde hiervan is “${item.value}”`
             )
-            helpers.setFieldTouched('File', true)
         })
+    }
 
     helpers.setSubmitting(false)
 }


### PR DESCRIPTION
[Bug 38073](https://dev.azure.com.mcas.ms/pzh-nl/Omgevingsbeleid/_workitems/edit/38073?McasTsid=26110&McasCtx=4): "Gekoppelde documenten" bij een maatregel niet zichtbaar, indien wel zichtbaar niet te openen