### PR TITLE
AB#24596 AB#35375 - Gebieden en gebiedengroepen laten werken in de front-end (FE)

### DIFF
--- a/src/components/DynamicObject/ObjectArea/ObjectArea.tsx
+++ b/src/components/DynamicObject/ObjectArea/ObjectArea.tsx
@@ -1,55 +1,70 @@
-import { Heading, Text } from '@pzh-ui/components'
+import { Heading, Notification, Text } from '@pzh-ui/components'
 
-import { WerkingsgebiedStatics } from '@/api/fetchers.schemas'
+import { ObjectStatics } from '@/api/fetchers.schemas'
 import { LeafletTinyViewer } from '@/components/Leaflet'
 import { Model } from '@/config/objects/types'
 import { useArea } from '@/hooks/useArea'
+import { LayerGroupLight, Lightbulb } from '@pzh-ui/icons'
 
-interface ObjectAreaProps extends WerkingsgebiedStatics {
+interface ObjectAreaProps {
     objectTitle?: string
     model: Model
+    area?: ObjectStatics | null
 }
 
-const ObjectArea = ({
-    objectTitle,
+const ObjectArea = ({ objectTitle, model, area }: ObjectAreaProps) => {
+    const { singular, demonstrative } = model.defaults
+
+    return (
+        <div data-section="Gebiedengroep">
+            <Heading level="2" className="mb-4">
+                Gebiedengroep
+            </Heading>
+
+            {!!area ? (
+                <Viewer model={model} objectTitle={objectTitle} {...area} />
+            ) : (
+                <p>
+                    Op {demonstrative} {singular} is het ambtsgebied van
+                    toepassing.
+                </p>
+            )}
+        </div>
+    )
+}
+
+const Viewer = ({
     model,
+    objectTitle,
     Object_ID,
     Cached_Title,
-}: ObjectAreaProps) => {
+}: ObjectStatics & ObjectAreaProps) => {
     const { singular, prefixSingular } = model.defaults
 
     const data = useArea(Object_ID)
 
     return (
-        <div data-section="Werkingsgebied">
-            <Heading level="2" className="mb-4">
-                Gebiedengroep
-            </Heading>
+        <>
             <Text className="mb-4 first-letter:capitalize">
                 {prefixSingular} {singular} ‘{objectTitle}’ heeft als
                 gebiedengroep ‘{data?.Title || Cached_Title}’.
             </Text>
 
-            {!!data && (
-                <>
-                    {/* <Notification icon={Lightbulb} className="mb-3">
-                        <>
-                            Tip! Gebruik het icoon{' '}
-                            <LayerGroup
-                                size={18}
-                                className="text-pzh-blue-900 mx-1 -mt-1 inline"
-                            />{' '}
-                            om de kaartlagen binnen dit werkingsgebied te
-                            bekijken
-                        </>
-                    </Notification> */}
+            <Notification icon={Lightbulb} className="mb-3">
+                <p>
+                    Tip! Gebruik het icoon{' '}
+                    <LayerGroupLight
+                        size={18}
+                        className="text-pzh-blue-900 mx-1 -mt-1 inline"
+                    />{' '}
+                    om de kaartlagen binnen deze gebiedengroep te bekijken.
+                </p>
+            </Notification>
 
-                    <div className="h-125 overflow-hidden rounded-lg">
-                        <LeafletTinyViewer uuid={data.Source_UUID || ''} />
-                    </div>
-                </>
-            )}
-        </div>
+            <div className="h-125 overflow-hidden rounded-lg">
+                <LeafletTinyViewer uuid={data?.Source_UUID || ''} isSource />
+            </div>
+        </>
     )
 }
 

--- a/src/components/DynamicObject/ObjectRevision/ObjectRevision.tsx
+++ b/src/components/DynamicObject/ObjectRevision/ObjectRevision.tsx
@@ -81,8 +81,8 @@ const ObjectRevision = ({
                 )
             })}
 
-            {(!!revisionTo.Werkingsgebied_Statics ||
-                !!revisionFrom.Werkingsgebied_Statics) &&
+            {(!!revisionTo.Gebiedengroep_Static ||
+                !!revisionFrom.Gebiedengroep_Static) &&
                 ((!!!user && !moduleId) || !!user) && (
                     <>
                         <Divider className="mt-0 mb-6" />
@@ -92,28 +92,27 @@ const ObjectRevision = ({
                         </Heading>
 
                         <Text className="mb-3">
-                            {revisionTo.Werkingsgebied_Statics?.Object_ID ===
-                            revisionFrom.Werkingsgebied_Statics?.Object_ID
-                                ? `Het gebied '${revisionTo.Werkingsgebied_Statics?.Cached_Title}' in ${singularReadable} '${revisionTo.Title}' is ongewijzigd.`
-                                : !!revisionTo.Werkingsgebied_Statics
+                            {revisionTo.Gebiedengroep_Static?.Object_ID ===
+                            revisionFrom.Gebiedengroep_Static?.Object_ID
+                                ? `Het gebied '${revisionTo.Gebiedengroep_Static?.Cached_Title}' in ${singularReadable} '${revisionTo.Title}' is ongewijzigd.`
+                                : !!revisionTo.Gebiedengroep_Static
                                         ?.Object_ID &&
-                                    !!revisionFrom.Werkingsgebied_Statics
+                                    !!revisionFrom.Gebiedengroep_Static
                                         ?.Object_ID
                                   ? `${singularCapitalize} '${revisionTo.Title}' is gewijzigd van gebied '${revisionTo.Werkingsgebied_Statics?.Cached_Title}' naar gebied '${revisionFrom.Werkingsgebied_Statics?.Cached_Title}'`
-                                  : !!revisionTo.Werkingsgebied_Statics
-                                          ?.Object_ID
-                                    ? `Het gebied '${revisionTo.Werkingsgebied_Statics?.Cached_Title}' in ${singularReadable} '${revisionTo.Title}' is verwijderd.`
-                                    : `Het gebied '${revisionFrom.Werkingsgebied_Statics?.Cached_Title}' in ${singularReadable} '${revisionTo.Title}' is toegevoegd.`}
+                                  : !!revisionTo.Gebiedengroep_Static?.Object_ID
+                                    ? `Het gebied '${revisionTo.Gebiedengroep_Static?.Cached_Title}' in ${singularReadable} '${revisionTo.Title}' is verwijderd.`
+                                    : `Het gebied '${revisionFrom.Gebiedengroep_Static?.Cached_Title}' in ${singularReadable} '${revisionTo.Title}' is toegevoegd.`}
                         </Text>
 
                         <div className="h-[320px] overflow-hidden rounded-lg">
                             <LeafletRevisionOverview
                                 id={`revision-map-${initialObject?.UUID}`}
                                 area={{
-                                    type: 'Werkingsgebieden',
-                                    old: revisionFrom.Werkingsgebied_Statics
+                                    type: 'Gebiedengroep',
+                                    old: revisionFrom.Gebiedengroep_Static
                                         ?.Object_ID,
-                                    new: revisionTo.Werkingsgebied_Statics
+                                    new: revisionTo.Gebiedengroep_Static
                                         ?.Object_ID,
                                 }}
                             />
@@ -121,17 +120,17 @@ const ObjectRevision = ({
                         <div className="mt-3 space-y-1">
                             <span className="flex items-center">
                                 <div className="border-pzh-red-500 mr-2 h-[14px] w-[14px] rounded-full border bg-[repeating-linear-gradient(-45deg,#D11F3D_0px,#D11F3D_2px,white_2px,white_4px)]" />
-                                Verwijderd werkingsgebied
+                                Verwijderde gebiedengroep
                             </span>
 
                             <span className="flex items-center">
                                 <div className="border-pzh-green-500 mr-2 h-[14px] w-[14px] rounded-full border bg-[repeating-linear-gradient(45deg,#00804D_0px,#00804D_2px,white_2px,white_4px)]" />
-                                Toegevoegd werkingsgebied
+                                Toegevoegde gebiedengroep
                             </span>
 
                             <span className="flex items-center">
                                 <div className="border-pzh-blue-500 mr-2 h-[14px] w-[14px] rounded-full border bg-[repeating-linear-gradient(0deg,#281F6B_0px,#281F6B_2px,white_2px,white_4px)]" />
-                                Ongewijzigd werkingsgebied
+                                Ongewijzigde gebiedengroep
                             </span>
                         </div>
                     </>

--- a/src/components/Leaflet/LeafletMap/LeafletMap.tsx
+++ b/src/components/Leaflet/LeafletMap/LeafletMap.tsx
@@ -42,7 +42,7 @@ const LeafletMap = forwardRef<Map, LeafletMapProps>(
             className,
             id,
             children,
-            ariaLabel = 'Visuele weergave van het werkingsgebied',
+            ariaLabel = 'Visuele weergave van de gebiedengroep',
         },
         ref
     ) => {

--- a/src/components/Leaflet/LeafletRevisionOverview/LeafletRevisionOverview.tsx
+++ b/src/components/Leaflet/LeafletRevisionOverview/LeafletRevisionOverview.tsx
@@ -49,7 +49,7 @@ const LeafletRevisionOverviewInner = ({
 
     const map = useMap()
 
-    const [werkingsgebied, setWerkingsgebied] = useState<FeatureLayer[]>([])
+    const [areaLayers, setAreaLayers] = useState<FeatureLayer[]>([])
     const layerRefs = useRef<{
         from?: Leaflet.GeoJSON | null
         to?: Leaflet.GeoJSON | null
@@ -155,7 +155,7 @@ const LeafletRevisionOverviewInner = ({
             map.removeLayer(layerRefs.current.to)
         }
         layerRefs.current = { from: null, to: null }
-        setWerkingsgebied([])
+        setAreaLayers([])
 
         const mainData = {
             from: geoQueries[0]?.data,
@@ -241,7 +241,7 @@ const LeafletRevisionOverviewInner = ({
         const items: Layer[] = []
         layerRefs.current.from?.eachLayer((l: Layer) => items.push(l))
         layerRefs.current.to?.eachLayer((l: Layer) => items.push(l))
-        setWerkingsgebied(items)
+        setAreaLayers(items)
 
         return () => {
             if (
@@ -254,7 +254,7 @@ const LeafletRevisionOverviewInner = ({
                 map.removeLayer(layerRefs.current.to)
             }
             layerRefs.current = { from: null, to: null }
-            setWerkingsgebied([])
+            setAreaLayers([])
         }
     }, [map, area, oldUUID, newUUID, geoQueries[0]?.data, geoQueries[1]?.data])
 
@@ -268,7 +268,7 @@ const LeafletRevisionOverviewInner = ({
         <LeafletControlLayer>
             <ToggleableSection title="Legenda" positionTop>
                 <ul className="p-2">
-                    {werkingsgebied?.map(layer => (
+                    {areaLayers?.map(layer => (
                         <LeafletAreaLayer
                             key={
                                 layer?.feature?.id ?? Leaflet.Util.stamp(layer)

--- a/src/pages/public/DynamicObject/DynamicObject.tsx
+++ b/src/pages/public/DynamicObject/DynamicObject.tsx
@@ -258,23 +258,20 @@ const DynamicObject = ({ model, isRevision }: DynamicObjectProps) => {
                         />
                     </div>
 
-                    {data?.Gebiedengroep_Static && (
-                        <div
-                            className={classNames('order-7', {
-                                'line-through': isTerminate,
-                            })}>
-                            <ObjectArea
-                                model={model}
-                                objectTitle={data.Title}
-                                {...data.Gebiedengroep_Static}
-                            />
-                        </div>
-                    )}
+                    <div
+                        className={classNames('order-7', {
+                            'line-through': isTerminate,
+                        })}>
+                        <ObjectArea
+                            model={model}
+                            objectTitle={data.Title}
+                            area={data.Gebiedengroep_Static}
+                        />
+                    </div>
 
                     {!!model.allowedConnections && (
                         <div
-                            className={classNames('order-8', {
-                                'mt-4 md:mt-8': !!data?.Werkingsgebied_Statics,
+                            className={classNames('order-8 mt-4 md:mt-8', {
                                 'line-through': isTerminate,
                             })}>
                             <ObjectConnectionsPublic


### PR DESCRIPTION
[User Story 24596](https://dev.azure.com.mcas.ms/pzh-nl/Omgevingsbeleid/_workitems/edit/24596?McasTsid=26110&McasCtx=4): Gebieden en gebiedengroepen laten werken in de front-end (FE)
[User Story 35375](https://dev.azure.com.mcas.ms/pzh-nl/Omgevingsbeleid/_workitems/edit/35375?McasTsid=26110&McasCtx=4): Objecten zonder gebiedengroep, benoemen dat ambtsgebied van toepassing is