### PR TITLE
AB#39250 - Overzicht wordt niet vernieuwd na opslaan 'niet-module-object'

### DIFF
--- a/src/pages/protected/DynamicObject/ObjectWrite/ObjectWrite.tsx
+++ b/src/pages/protected/DynamicObject/ObjectWrite/ObjectWrite.tsx
@@ -121,6 +121,8 @@ const ObjectWrite = ({ model }: ObjectWriteProps) => {
                                             }),
                                             queryClient.invalidateQueries({
                                                 queryKey: validQueryKey,
+                                                refetchType: 'all',
+                                                exact: false,
                                             }),
                                             queryClient.invalidateQueries({
                                                 queryKey: relationsQueryKey,

--- a/src/pages/protected/DynamicOverview/DynamicOverview.tsx
+++ b/src/pages/protected/DynamicOverview/DynamicOverview.tsx
@@ -238,7 +238,7 @@ const TabTable = ({ type, activeTab, model, query }: TabTableProps) => {
                     | ModelReturnTypeBasicUnion
                 )[]
             )?.map(props => {
-                const { Title, Modified_Date, Object_ID } =
+                const { Title, Object_ID } =
                     'Model' in props ? props.Model : props
 
                 return {


### PR DESCRIPTION
[Bug 39250](https://dev.azure.com.mcas.ms/pzh-nl/Omgevingsbeleid/_workitems/edit/39250?McasTsid=26110&McasCtx=4): Overzicht wordt niet vernieuwd na opslaan 'niet-module-object'